### PR TITLE
Potential fix for code scanning alert no. 3: Unvalidated dynamic method call

### DIFF
--- a/client/src/services/vscode/index.ts
+++ b/client/src/services/vscode/index.ts
@@ -38,8 +38,13 @@ class VSCodeAPIWrapper {
         arg0: HandlerArgs<Required<MessageHandlersView>>
       ) => void
 
-      if (typeof handler === 'function') {
+      if (
+        Object.prototype.hasOwnProperty.call(this.messageHandlers, type) &&
+        typeof handler === 'function'
+      ) {
         handler(event.data.data)
+      } else {
+        console.warn('[VSCodeAPIWrapper] Ignored message with invalid handler:', type)
       }
     })
   }


### PR DESCRIPTION
Potential fix for [https://github.com/JairTorres1003/JT-View-Exports-SVG/security/code-scanning/3](https://github.com/JairTorres1003/JT-View-Exports-SVG/security/code-scanning/3)

To fix this unvalidated dynamic method call, it's necessary to validate the lookup before invoking the handler. This requires:
- Ensuring the property being called is a direct property (not inherited) of the handlers object.
- Ensuring that the target is actually a function.
- Optionally, maintaining a whitelist of allowed message types, or using a `Map` rather than an object for the handlers.

Within the code shown, the best solution is to add checks in the event listener (lines 35–44) to make sure:
1. `type` is a string (or an allowed enum value).
2. `handler` is a function.
3. The property exists as an "own property" (not from the prototype chain).

Edit the code around line 41 so that the handler is only called if the above validations pass, and otherwise ignore the message or log a warning. No other changes or new methods are strictly required, though optionally you may wish to log when a bad message type is received.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
